### PR TITLE
Initialize GameState Values

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -39,6 +39,7 @@ Game::Game(const std::string& map_file, Config config):
 Game::~Game() = default;
 
 void Game::_internalInit(){
+    state.fill(-1);
     players.reserve(Constants::MAX_PLAYERS);
     units.reserve(Constants::MAX_PLAYERS * Constants::MAX_UNITS);
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -39,7 +39,7 @@ Game::Game(const std::string& map_file, Config config):
 Game::~Game() = default;
 
 void Game::_internalInit(){
-    state.fill(-1);
+    state.fill(-1.);
     players.reserve(Constants::MAX_PLAYERS);
     units.reserve(Constants::MAX_PLAYERS * Constants::MAX_UNITS);
 


### PR DESCRIPTION
The State for the game has uninitialized values, making the array have enormous values when training. This PR fixes this by initializing the state array with -1's. I chose -1 because the game state is updated every tick, and can contain 0's as a part of the game, so its best to initialize with a otherwize unused value (-1).

![image](https://user-images.githubusercontent.com/46325452/232434677-79167475-f57b-459d-8a8b-fcf5d8c65a50.png)
